### PR TITLE
Fix typo in twaddle-callback-handler

### DIFF
--- a/twaddle.el
+++ b/twaddle.el
@@ -291,7 +291,7 @@ then sends HTML back to eww."
                (elnode-http-params httpcon)))
     (twaddle/web
      (lambda (con hdr data)
-       (let ((alist (elnode-http-query-to-alist data)))
+       (let ((alist (elnode--http-query-to-alist data)))
          ;; Save the auth data
          (setq twaddle/auth-details alist)
          ;; Show the timeline


### PR DESCRIPTION
The function 'elnode-http-query-to-alist' should be 'elnode--http-query-to-alist'.
